### PR TITLE
add react native support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @digitalbazaar/data-integrity Changelog
 
+## 2.6.0 - TBD
+
+### Added
+- adds support for react native
+
 ## 2.5.0 - 2024-09-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @digitalbazaar/data-integrity Changelog
 
-## 2.6.0 - TBD
+## 2.6.0 - 2025-04-30
 
 ### Added
 - adds support for react native

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @digitalbazaar/data-integrity Changelog
+# @digitalcredentials/data-integrity Changelog
 
 ## 2.6.0 - 2025-04-30
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
-# Data Integrity library _(@digitalbazaar/data-integrity)_
+# Data Integrity library _(@digitalcredentials/data-integrity)_
 
-[![Build status](https://img.shields.io/github/actions/workflow/status/digitalbazaar/data-integrity/main.yml)](https://github.com/digitalbazaar/data-integrity/actions?query=workflow%3A%22Node.js+CI%22)
-[![Coverage status](https://img.shields.io/codecov/c/github/digitalbazaar/data-integrity)](https://codecov.io/gh/digitalbazaar/data-integrity)
-[![NPM Version](https://img.shields.io/npm/v/@digitalbazaar/data-integrity.svg)](https://npm.im/@digitalbazaar/data-integrity)
+[![Build status](https://img.shields.io/github/actions/workflow/status/digitalcredentials/data-integrity/main.yml)](https://github.com/digitalcredentials/data-integrity/actions?query=workflow%3A%22Node.js+CI%22)
+[![NPM Version](https://img.shields.io/npm/v/@digitalcredentials/data-integrity.svg)](https://npm.im/@digitalcredentials/data-integrity)
 
 > DataIntegrity library for use with cryptosuites and jsonld-signatures.
+
+NOTE this is a fork of @digitalbazaar/data-integrity that adds support for react native by adding a react-native override in package.json that shims in a react native compatible sha256digest library. It also replaces @digitalbazaar dependencies with @digitalcredential forks that in turn support react native.
 
 ## Table of Contents
 
@@ -13,12 +14,11 @@
 - [Install](#install)
 - [Usage](#usage)
 - [Contribute](#contribute)
-- [Commercial Support](#commercial-support)
 - [License](#license)
 
 ## Background
 
-For use with https://github.com/digitalbazaar/jsonld-signatures v11.0 and above.
+For use with https://github.com/digitalcredentials/jsonld-signatures v11.0 and above.
 
 See also related specs:
 
@@ -52,11 +52,11 @@ The following code snippet provides a complete example of digitally signing
 a verifiable credential using this library:
 
 ```javascript
-import * as Ed25519Multikey from '@digitalbazaar/ed25519-multikey';
-import {DataIntegrityProof} from '@digitalbazaar/data-integrity';
+import * as Ed25519Multikey from '@digitalcredentials/ed25519-multikey';
+import {DataIntegrityProof} from '@digitalcredentials/data-integrity';
 import {cryptosuite as eddsa2022CryptoSuite} from
-  '@digitalbazaar/eddsa-2022-cryptosuite';
-import jsigs from 'jsonld-signatures';
+  '@digitalcredentials/eddsa-2022-cryptosuite';
+import jsigs from '@digitalcredentials/jsonld-signatures';
 const {purposes: {AssertionProofPurpose}} = jsigs;
 
 
@@ -157,18 +157,7 @@ https://w3id.org/security/data-integrity/v1) to be used.
 
 ## Contribute
 
-See [the contribute file](https://github.com/digitalbazaar/bedrock/blob/master/CONTRIBUTING.md)!
-
 PRs accepted.
 
 If editing the Readme, please conform to the
 [standard-readme](https://github.com/RichardLitt/standard-readme) specification.
-
-## Commercial Support
-
-Commercial support for this library is available upon request from
-Digital Bazaar: support@digitalbazaar.com
-
-## License
-
-[New BSD License (3-clause)](LICENSE) © 2022 Digital Bazaar

--- a/README.md
+++ b/README.md
@@ -161,3 +161,7 @@ PRs accepted.
 
 If editing the Readme, please conform to the
 [standard-readme](https://github.com/RichardLitt/standard-readme) specification.
+
+## License
+
+[MIT License](LICENSE.md) © 2025 Digital Credentials Consortium.

--- a/lib/sha256digest-reactnative.js
+++ b/lib/sha256digest-reactnative.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2025 Digital Credentials Consortium - React Native addition.
+ * Copyright (c) 2021 Digital Bazaar, Inc. All rights reserved.
+ */
+import * as Crypto from 'expo-crypto';
+import 'fast-text-encoding';
+
+  /**
+   * Hashes a string of data using SHA-256.
+   *
+   * @param {string} string - the string to hash.
+   *
+   * @return {Uint8Array} the hash digest.
+   */
+  export async function sha256digest({string}) {
+    const bytes = new TextEncoder().encode(string);
+    return new Uint8Array(
+      await Crypto.digest(Crypto.CryptoDigestAlgorithm.SHA256, bytes));
+  }
+
+
+

--- a/lib/sha256digest-reactnative.js
+++ b/lib/sha256digest-reactnative.js
@@ -5,18 +5,16 @@
 import * as Crypto from 'expo-crypto';
 import 'fast-text-encoding';
 
-  /**
+/**
    * Hashes a string of data using SHA-256.
    *
-   * @param {string} string - the string to hash.
+   * @param {string} string - The string to hash.
    *
-   * @return {Uint8Array} the hash digest.
+   * @returns {Uint8Array} The hash digest.
    */
-  export async function sha256digest({string}) {
-    const bytes = new TextEncoder().encode(string);
-    return new Uint8Array(
-      await Crypto.digest(Crypto.CryptoDigestAlgorithm.SHA256, bytes));
-  }
-
-
+export async function sha256digest({string}) {
+  const bytes = new TextEncoder().encode(string);
+  return new Uint8Array(
+    await Crypto.digest(Crypto.CryptoDigestAlgorithm.SHA256, bytes));
+}
 

--- a/package.json
+++ b/package.json
@@ -15,12 +15,20 @@
   ],
   "browser": {
     "crypto": false,
-    "./lib/sha256digest.js": "./lib/sha256digest-browser.js"
+    "./lib/sha256digest.js": "./lib/sha256digest-browser.js",
+    "./lib/sha256digest-reactnative.js": false,
+    "fast-text-encoding": false
+  },
+  "react-native": {
+    "crypto": false,
+    "./lib/sha256digest.js": "./lib/sha256digest-reactnative.js",
+    "./lib/sha256digest-browser.js": false
   },
   "dependencies": {
     "@digitalcredentials/jsonld-signatures": "^12.0.1",
     "base58-universal": "^2.0.0",
-    "base64url-universal": "^2.0.0"
+    "base64url-universal": "^2.0.0",
+    "fast-text-encoding": "^1.0.6"
   },
   "devDependencies": {
     "@digitalbazaar/data-integrity-context": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitalcredentials/data-integrity",
-  "version": "2.5.1-beta.1",
+  "version": "2.6.0",
   "description": "Data Integrity Proof library for use with jsonld-signatures.",
   "homepage": "https://github.com/digitalcredentials/data-integrity",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitalcredentials/data-integrity",
-  "version": "2.5.1-0",
+  "version": "2.5.1-beta.1",
   "description": "Data Integrity Proof library for use with jsonld-signatures.",
   "homepage": "https://github.com/digitalcredentials/data-integrity",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitalcredentials/data-integrity",
-  "version": "2.6.0-beta.1",
+  "version": "2.6.0",
   "description": "Data Integrity Proof library for use with jsonld-signatures.",
   "homepage": "https://github.com/digitalcredentials/data-integrity",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/digitalcredentials/data-integrity"
   },
-  "license": "BSD-3-Clause",
+  "license": "MIT",
   "type": "module",
   "exports": "./lib/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitalcredentials/data-integrity",
-  "version": "2.6.0",
+  "version": "2.6.0-beta.1",
   "description": "Data Integrity Proof library for use with jsonld-signatures.",
   "homepage": "https://github.com/digitalcredentials/data-integrity",
   "repository": {


### PR DESCRIPTION
Adds a react-native override in package.json that shims in a react native compatible sha256digest library. It also replaces @digitalbazaar dependencies with @digitalcredential forks that in turn support react native.